### PR TITLE
Fix: Updated library version for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Required packages are
 torch
 torchvision
 tensorboardX
-scikit-image==0.16.2
+scikit-image==0.18.0
 ```
 The version of torch/torchvison is not restricted for inference.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ numpy>=1.21
 opencv-python
 pandas
 Pillow
-scikit-image==0.16.2
+scikit-image==0.18.0
 tensorboard
 tensorboardX
 tifffile==2020.9.3


### PR DESCRIPTION
This pull request updates the version of scikit-image==0.16.2 to 0.18.0 in the project to ensure compatibility with the latest features and dependencies. The previous version didnt contain skimage.draw.circle method needed to run the code.